### PR TITLE
Order doesnt refresh on keyup. Pse doesnt change randomly

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <authors>
         <author>
             <name>Gilles Bourgeat</name>

--- a/templates/backOffice/default/admin-order-creation/assets/js/script.js
+++ b/templates/backOffice/default/admin-order-creation/assets/js/script.js
@@ -251,14 +251,14 @@
             }));
         });
 
-        $form.on('keyup change', '.js-action-refresh', function(event){
+        $form.on('change', '.js-action-refresh', function(event){
             if ($(this).val().length) {
                 refreshWithTimer($form, event);
             }
         });
 
         var currentProductRequestTax;
-        $form.on('keyup', '.js-product-price-with-tax, .js-product-price-without-tax', function(event){
+        $form.on('change', '.js-product-price-with-tax, .js-product-price-without-tax', function(event){
             if (currentProductRequestTax) currentProductRequestTax.abort();
 
             var $th = $(this), $thr = $(this).parents('tr');
@@ -335,7 +335,7 @@
         var $shippingArea = $form.find('.js-shipping-area');
 
         var currentRequestTax;
-        $shippingArea.on('keyup', '.js-field-amount-without-tax, .js-field-amount-with-tax', function(event){
+        $shippingArea.on('change', '.js-field-amount-without-tax, .js-field-amount-with-tax', function(event){
             if (currentRequestTax) currentRequestTax.abort();
 
             var $th = $(this), $thr = $shippingArea;

--- a/templates/backOffice/default/admin-order-creation/include/product-line.html
+++ b/templates/backOffice/default/admin-order-creation/include/product-line.html
@@ -2,7 +2,7 @@
     <td>
         {form_field field='product_id' value_key=$key}
         {if $orderProduct}
-            {loop type="product_sale_elements" name="product-sale-element-price-$key" id=$orderProduct->getProductSaleElementsId() currency=$currency_id backend_context=true}
+            {loop type="product_sale_elements" order="id" name="product-sale-element-price-$key" id=$orderProduct->getProductSaleElementsId() currency=$currency_id backend_context=true}
                 {$product_id = $PRODUCT_ID}
             {/loop}
         {/if}
@@ -23,7 +23,7 @@
                 {if $product_id}
                     {$attributeCombinations = []}
                     {$PSE_first = null}
-                    {loop type="product_sale_elements" name="product-sale-element-$key" product=$product_id currency=$currency_id backend_context=true}
+                    {loop type="product_sale_elements" order="id" name="product-sale-element-$key" product=$product_id currency=$currency_id backend_context=true}
                     {$PSE_id = $ID}
                     {if !$PSE_first}
                         {$PSE_first = $ID}
@@ -35,7 +35,7 @@
 
                     {if $attributeCombinations|count}
                         <select class="form-control js-select-product-sale-element" name="{$name}" >
-                            {loop type="product_sale_elements" name="product-sale-element-$key" product=$product_id currency=$currency_id}
+                            {loop type="product_sale_elements" order="id" name="product-sale-element-$key" product=$product_id currency=$currency_id}
                             {$selected = false}
                             {if !$orderProduct->getProductSaleElementsId() and $PSE_first == $ID}
                                 {$productSaleEmenetIdSelected = $ID}
@@ -56,7 +56,7 @@
                     {else}
                         {intl l="Default product sale element" d="adminordercreation.bo.default"}
 
-                        {loop type="product_sale_elements" name="product-sale-element-$key" product=$product_id limit=1 currency=$currency_id backend_context=true}
+                        {loop type="product_sale_elements" order="id" name="product-sale-element-$key" product=$product_id limit=1 currency=$currency_id backend_context=true}
                         {$productSaleEmenetIdSelected = $ID}
                             <input type="hidden" value="{$ID}" name="{$name}" />
                         {/loop}
@@ -69,7 +69,7 @@
         {if $product_id}
             {if $productSaleEmenetIdSelected}
 
-                {loop type="product_sale_elements" name="product-sale-element-price-$key" id=$productSaleEmenetIdSelected currency=$currency_id backend_context=true}
+                {loop type="product_sale_elements" order="id" name="product-sale-element-price-$key" id=$productSaleEmenetIdSelected currency=$currency_id backend_context=true}
                     {form_field field='refresh_price' value_key=$key}
                         <input class="js-refresh-price" type="hidden" name="{$name}" value="0" />
                     {/form_field}
@@ -118,7 +118,7 @@
         {form_field field='product_quantity' value_key=$key}
             <div class="form-group">
                 {if $product_id}
-                    {loop type="product_sale_elements" name="product-sale-element-quanaity-$key" id=$productSaleEmenetIdSelected currency=$currency_id backend_context=true}
+                    {loop type="product_sale_elements" order="id" name="product-sale-element-quanaity-$key" id=$productSaleEmenetIdSelected currency=$currency_id backend_context=true}
                         <input class="form-control js-action-refresh" type="number" min="1" step="1"  name="{$name}" value="{$orderProduct->getQuantity()}" />
                     {/loop}
                 {/if}
@@ -127,7 +127,7 @@
     </td>
     <td>
         {if $productSaleEmenetIdSelected}
-        {loop type="product_sale_elements" name="product-sale-element-price-$key" id=$productSaleEmenetIdSelected currency=$currency_id backend_context=true}
+        {loop type="product_sale_elements" order="id" name="product-sale-element-price-$key" id=$productSaleEmenetIdSelected currency=$currency_id backend_context=true}
             <div class="form-group">
                 <div class="input-group">
                     <input class="form-control js-action-refresh" type="number" min="0" step="0.000001" disabled value="{format_number number=($priceWithoutTax * $orderProduct->getQuantity()) dec_point="." decimals="6"}" />


### PR DESCRIPTION
- Order do not refresh or call a method on keyup when modifying prices anymore, as it stopped the user from entering the while new number before a refresh if he didn't hurry enough.
- PSE is not modified randomly anymore when changing its price